### PR TITLE
Improve cube-sphere grid uniformity and controls

### DIFF
--- a/Assets/Scripts/PlayerMoverSphere.cs
+++ b/Assets/Scripts/PlayerMoverSphere.cs
@@ -10,6 +10,7 @@ public class PlayerMoverSphere : MonoBehaviour
     public float moveCooldown = 0.08f;
 
     private float nextMoveTime;
+    private Vector2Int lastStepDir = Vector2Int.up;
 
     void Start()
     {
@@ -22,12 +23,19 @@ public class PlayerMoverSphere : MonoBehaviour
     void Update()
     {
         if (Keyboard.current == null) return;
-        if (Time.time < nextMoveTime) return;
 
         Vector2Int dir = ReadStep();
-        if (dir == Vector2Int.zero) return;
+        if (dir == Vector2Int.zero)
+        {
+            nextMoveTime = Mathf.Min(nextMoveTime, Time.time);
+            return;
+        }
+
+        if (Time.time < nextMoveTime)
+            return;
 
         grid.Step(ref face, ref i, ref j, dir.x, dir.y);
+        lastStepDir = dir;
         SnapToCell();
 
         nextMoveTime = Time.time + moveCooldown;
@@ -35,11 +43,28 @@ public class PlayerMoverSphere : MonoBehaviour
 
     Vector2Int ReadStep()
     {
-        if (Keyboard.current.wKey.wasPressedThisFrame || Keyboard.current.upArrowKey.wasPressedThisFrame) return new Vector2Int(0, +1);
-        if (Keyboard.current.sKey.wasPressedThisFrame || Keyboard.current.downArrowKey.wasPressedThisFrame) return new Vector2Int(0, -1);
-        if (Keyboard.current.aKey.wasPressedThisFrame || Keyboard.current.leftArrowKey.wasPressedThisFrame) return new Vector2Int(-1, 0);
-        if (Keyboard.current.dKey.wasPressedThisFrame || Keyboard.current.rightArrowKey.wasPressedThisFrame) return new Vector2Int(+1, 0);
-        return Vector2Int.zero;
+        var kb = Keyboard.current;
+        Vector2 input = Vector2.zero;
+
+        if (kb.wKey.isPressed || kb.upArrowKey.isPressed) input += Vector2.up;
+        if (kb.sKey.isPressed || kb.downArrowKey.isPressed) input += Vector2.down;
+        if (kb.aKey.isPressed || kb.leftArrowKey.isPressed) input += Vector2.left;
+        if (kb.dKey.isPressed || kb.rightArrowKey.isPressed) input += Vector2.right;
+
+        if (input.sqrMagnitude < 0.01f)
+            return Vector2Int.zero;
+
+        // wybierz dominującą oś (tylko jedna na raz)
+        if (Mathf.Abs(input.x) > Mathf.Abs(input.y))
+            input = new Vector2(Mathf.Sign(input.x), 0f);
+        else if (Mathf.Abs(input.y) > Mathf.Abs(input.x))
+            input = new Vector2(0f, Mathf.Sign(input.y));
+        else if (lastStepDir != Vector2Int.zero)
+            input = lastStepDir;
+        else
+            input = new Vector2(0f, Mathf.Sign(input.y));
+
+        return new Vector2Int(Mathf.RoundToInt(input.x), Mathf.RoundToInt(input.y));
     }
 
     void SnapToCell()
@@ -48,15 +73,30 @@ public class PlayerMoverSphere : MonoBehaviour
         transform.position = p;
 
         Vector3 n = grid.SurfaceNormal(p);
-        transform.up = n;
 
-        // Wyznacz lokalny "wschód" (kierunek +i po stycznej), a forward ustaw w kierunku +j
         int ii = i, jj = j; var ff = face;
         grid.Step(ref ff, ref ii, ref jj, +1, 0);
         Vector3 pRight = grid.CellToWorldCenter(ff, ii, jj);
-        Vector3 rightTangent = Vector3.ProjectOnPlane((pRight - p).normalized, n).normalized;
+        Vector3 tangentI = Vector3.ProjectOnPlane(pRight - p, n).normalized;
 
-        if (rightTangent.sqrMagnitude > 0.0001f)
-            transform.forward = Vector3.Cross(n, rightTangent); // "do góry" siatki (oś j)
+        ii = i; jj = j; ff = face;
+        grid.Step(ref ff, ref ii, ref jj, 0, +1);
+        Vector3 pForward = grid.CellToWorldCenter(ff, ii, jj);
+        Vector3 tangentJ = Vector3.ProjectOnPlane(pForward - p, n).normalized;
+
+        if (tangentI.sqrMagnitude < 1e-6f)
+            tangentI = Vector3.Cross(tangentJ, n).normalized;
+        if (tangentJ.sqrMagnitude < 1e-6f)
+            tangentJ = Vector3.Cross(n, tangentI).normalized;
+
+        Vector3 forward = tangentJ;
+        Vector3 moveDir = tangentI * lastStepDir.x + tangentJ * lastStepDir.y;
+        if (moveDir.sqrMagnitude > 1e-6f)
+            forward = moveDir.normalized;
+
+        Vector3 right = Vector3.Cross(n, forward).normalized;
+        forward = Vector3.Cross(right, n).normalized;
+
+        transform.rotation = Quaternion.LookRotation(forward, n);
     }
 }


### PR DESCRIPTION
## Summary
- rework the cube-sphere UV remapping to better equalize cell shapes and expose a uniformCorners control
- allow continuous directional stepping while keeping the mover aligned to its latest travel direction
- offset the follow camera along tangential directions so it naturally orbits the sphere with adjustable parameters

## Testing
- not run (Unity Editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d861b8f7c083219beb70a836359a74